### PR TITLE
Tweak CWL output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * Ignore magic commands in input notebooks (#14)
 * Add NDVI sample notebook
 * Improve STAC output
+* Tweak CWL format (#24)
 
 ## Changes in 0.1.0
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - nbconvert
   - nbformat
   - pystac
-  - pyyaml
+  - pyyaml >=5.1  # need >=5.1 for sort_keys
   - xarray
   - xcube  # See note below
   # test dependencies

--- a/examples/dynamic/dynamic.ipynb
+++ b/examples/dynamic/dynamic.ipynb
@@ -25,7 +25,7 @@
     "tags": []
    },
    "source": [
-    "This notebook creates two simple synthetic datasets which are generated on the fly by xcube. It can be converted to a compute engine container using the `xcetool`."
+    "This notebook creates two simple synthetic datasets which are generated on the fly by xcube. It can be converted to a compute engine container using `xcetool`."
    ]
   },
   {

--- a/xcengine/cli.py
+++ b/xcengine/cli.py
@@ -150,7 +150,11 @@ def build(
             )
             image = image_builder.build()
     if eoap:
-        eoap.write_text(yaml.dump(image_builder.create_cwl()))
+        class IndentDumper(yaml.Dumper):
+            def increase_indent(self, flow=False, indentless=False):
+                return super(IndentDumper, self).increase_indent(flow, False)
+
+        eoap.write_text(yaml.dump(image_builder.create_cwl(), sort_keys=False, Dumper=IndentDumper))
     print(f"Built image with tags {image.tags}")
 
 

--- a/xcengine/core.py
+++ b/xcengine/core.py
@@ -107,9 +107,9 @@ class ScriptCreator:
 
     def create_cwl(self, image_tag: str) -> dict[str, Any]:
         script_id = "xce_script"
-        output_id = "xce_output"
+        output_id = "results"
         return {
-            "cwlVersion": "v1.2",
+            "cwlVersion": "v1.0",
             "$namespaces": {"s": "https://schema.org/"},
             "s:softwareVersion": "1.0.0",
             "schemas": [
@@ -118,16 +118,16 @@ class ScriptCreator:
             "$graph": [
                 {
                     "class": "Workflow",
+                    "id": "xcengine_ap",
                     "label": "xcengine notebook",
                     "doc": "xcengine notebook",
-                    "id": "main",
                     "requirements": [],
                     "inputs": self.nb_params.get_cwl_workflow_inputs(),
                     "outputs": [
                         {
                             "id": "stac_catalog",
-                            "outputSource": [f"run_script/{output_id}"],
                             "type": "Directory",
+                            "outputSource": [f"run_script/{output_id}"],
                         }
                     ],
                     "steps": {
@@ -144,6 +144,9 @@ class ScriptCreator:
                     "requirements": {
                         "DockerRequirement": {"dockerPull": image_tag}
                     },
+                    "hints": {
+                        "DockerRequirement": {"dockerPull": image_tag}
+                    },
                     "baseCommand": [
                         "python3",
                         "/home/mambauser/execute.py",
@@ -153,8 +156,8 @@ class ScriptCreator:
                     "inputs": self.nb_params.get_cwl_commandline_inputs(),
                     "outputs": {
                         output_id: {
-                            "outputBinding": {"glob": "."},
                             "type": "Directory",
+                            "outputBinding": {"glob": "."},
                         }
                     },
                 },

--- a/xcengine/parameters.py
+++ b/xcengine/parameters.py
@@ -101,10 +101,10 @@ class NotebookParameters:
     def get_cwl_workflow_input(self, var_name: str) -> dict[str, Any]:
         type_, default_ = self.params[var_name]
         return {
+            "label": var_name,
+            "doc": var_name,
             "type": self.cwl_type(type_),
             "default": default_,
-            "doc": var_name,
-            "label": var_name,
         }
 
     def get_cwl_commandline_input(self, var_name: str) -> dict[str, Any]:


### PR DESCRIPTION
Fixes #24

- Require pyyaml >=5.1.

- Fix a typo in an example notebook.

- In CWL output, don't sort dictionary keys.

- In CWL output, indent lists which are dictionary values.

- Change workflow output ID from "xce_output" to "results".

- Change workflow ID from "main" to "xcengine_ap".

- Change ordering of some CWL dictionary keys.

- Add a "hints" section to CommandLineTool, containing the same docker requirements as the "requirements" section.